### PR TITLE
Sort games by date instead of ID

### DIFF
--- a/js/Client/source.js
+++ b/js/Client/source.js
@@ -61,6 +61,10 @@ $.ajax({
 			{
 				return (a.id) - (b.id)
 			});
+			g_liveGames.sort(function(a,b)
+			{
+				return (a.date != b.date ? (a.date > b.date) - 0.5 : 0)
+			});
 			console.log(g_liveGames);
 			checkLiveGamesReady();
 		},


### PR DESCRIPTION
ID is mostly though not fully correlated with date, which occasionally leads to strange game orders. Sorting by date, with ID as a secondary key to ensure consistency, is probably more intuitive and helpful.